### PR TITLE
Fix value notify

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -25,7 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../paper-tags-dropdown.html">
   <link rel="import" href="../../hydrolysis/hydrolysis.html">
   <style is="custom-style" include="demo-pages-shared-styles">
-     
+
   </style>
 </head>
 
@@ -43,8 +43,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <demo-snippet class="centered-demo">
       <template>
         <template is="dom-bind">
-         <paper-tags-input label="input label" show-counter="tags" items='["hello", "new"]' value-join="{{valueJoin}}" maxLength="10"></paper-tags-input>
-          <div>value: {{valueJoin}}</div>
+          <paper-tags-input label="input label" show-counter="tags" items='["hello", "new"]' value="{{value}}" value-join="{{valueJoin}}" maxLength="10"></paper-tags-input>
+          <div>
+            <div>value: {{valueJoin}}</div>
+            <div>input value: {{value}}</div>
+          </div>
         </template>
       </template>
     </demo-snippet>
@@ -52,7 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <div class="vertical-section-container centered">
     <h4>paper-tags-dropdown</h4>
     <demo-snippet class="centered-demo">
-     
+
       <template>
         <template id="tagDropdown" is="dom-bind">
           <style is="custom-style">
@@ -67,9 +70,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </demo-snippet>
   </div>
- 
+
   <script>
+
   window.addEventListener('WebComponentsReady', function() {
+
     tagDropdown = document.querySelector('#tagDropdown');
     // app.listenSelect = function(e) {
     //   console.info('Listed', e);
@@ -78,7 +83,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       id: 1,
       desc: 'description 1',
       label: 'Title 1'
-   
+
     }, {
       id: '12345',
       desc: 'description 4',

--- a/paper-tags-input.html
+++ b/paper-tags-input.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <!--
 An element for settings tags tags, based on paper-input
 
-### Example: 
+### Example:
 
     <paper-tags-input label="input label" show-counter="tags" items='["hello", "new"]'  maxLength="10"></paper-tags-input>
 
@@ -24,7 +24,7 @@ The following custom properties and mixins are available for styling:
 
 Custom property | Description | Default
 ----------------|-------------|----------
-`--paper-tag-margin`   | bottom margin for tags | 3px        
+`--paper-tag-margin`   | bottom margin for tags | 3px
 
 @element paper-tags-input
 @demo demo/index.html
@@ -36,31 +36,31 @@ Custom property | Description | Default
       display: block;
       --paper-tag-margin: 3px;
     }
-    
+
     paper-input {
       --paper-input-container-input: {
         margin-bottom: var(--paper-tag-margin);
       }
     }
-    
+
     paper-tags {
       max-width: 80%;
     }
-    
+
     paper-tags[readonly] {
       opacity: 0.6;
     }
-    
+
     paper-badge {
       display: inline-block;
       position: inherit;
     }
-    
+
     .paper-tags-counter {
       display: inline-block;
     }
     </style>
-    <paper-input id="tagInput" always-float-label on-keydown="_keyDown" readonly$="[[readonly]]" placeholder$="[[placeholder]]" disabled$="[[disabled]]" invalid="[[invalid]]" label="[[label]]" bind-value="{{value}}" maxlength$="[[maxlength]]" error-message="[[errorMessage]]" minlength$="[[minlength]]" invalid="{{invalid}}">
+    <paper-input id="tagInput" always-float-label on-keydown="_keyDown" readonly$="[[readonly]]" placeholder$="[[placeholder]]" disabled$="[[disabled]]" invalid="[[invalid]]" label="[[label]]" value="{{value}}" maxlength$="[[maxlength]]" error-message="[[errorMessage]]" minlength$="[[minlength]]" invalid="{{invalid}}">
       <content select="[prefix]" prefix></content>
       <paper-tags id="paperTags" readonly$="[[readonly]]" items="{{items}}" icon="[[icon]]" item-class="[[itemClass]]" class-accessor="[[classAccessor]]" label-accessor="[[labelAccessor]]" icon-accessor="[[iconAccessor]]" prevent-remove-tag="[[preventRemoveTag]]" prefix></paper-tags>
       <content select="[suffix]" suffix></content>
@@ -78,7 +78,7 @@ Polymer({
 
   properties: {
     /**
-     * `preventRemoveTag` hide the `close` icon and prevent removing a tag when true. 
+     * `preventRemoveTag` hide the `close` icon and prevent removing a tag when true.
      */
     preventRemoveTag: {
       type: Boolean,

--- a/paper-tags-input.html
+++ b/paper-tags-input.html
@@ -113,9 +113,12 @@ Polymer({
     tagTpl: Object,
 
     /**
-     * The `value` for this input. If you're using PaperInputBehavior to implement your own paper-input-like element, bind this to the <input is="iron-input">'s bindValue property, or the value property of your input that is notify:true.
+     * `value` the underlying paper-input value
      */
-    value: String,
+    value: {
+      type: String,
+      notify: true
+    },
 
     /**
      * `allowAdd` determines if new tags are allowed on pressing `Enter` or not.
@@ -130,7 +133,6 @@ Polymer({
   ],
 
   behaviors: [
-    Polymer.PaperInputBehavior,
     Polymer.PaperTagsBehavior
   ],
 


### PR DESCRIPTION
For me  the "paper-input" should bind to the "value" property. The "bind-value" property is for "input is='iron-input'".
The "value" property should notify and the "PaperInputBehavior" is not needed, as it is already implemented in the "paper-input"-element.

Cheers,

Jan

