### PR TITLE
Fixes a bug with using the paper-tags-dropdown with a string array

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -69,6 +69,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </demo-snippet>
   </div>
+  <div class="vertical-section-container centered">
+	<h4>paper-tags-dropdown string array</h4>
+	<demo-snippet class="centered-demo">
+		<template>
+			<template id="stringArrayTagDropdown" is="dom-bind">
+				<style is="custom-style">
+					paper-tags-dropdown {
+						--paper-menu: {
+							width: 200px;
+						}
+					}
+				</style>
+				<paper-tags-dropdown
+					id="stringControl"
+					items='["Doe", "Rae", "Mee", "Faa", "So", "Laa", "Tee", "Daa"]'
+					label-path="label"
+					noink
+					label="label dropdown"
+					value-array='["Rae"]'>
+				</paper-tags-dropdown>
+			</template>
+		</template>
+	</demo-snippet>
+  </div>
   <script>
   window.addEventListener('WebComponentsReady', function() {
 
@@ -97,7 +121,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     setTimeout(function() {
       tagDropdown.$.control.set('items', data)
     }, 100);
-    
+
     tagDropdown.$.control.addEventListener('tag-removed', function(e, d) {
       console.log("tag-removed", e.detail);
     }.bind(this));

--- a/paper-tags-dropdown.html
+++ b/paper-tags-dropdown.html
@@ -60,12 +60,12 @@ Custom property | Description | Default
     :host: {
       display: block;
     }
-    
+
     #filterCt {
       color: var(--default-primary-color);
       padding: 2px 8;
     }
-    
+
     paper-menu {
       min-width: 150px;
       @apply(--paper-menu);
@@ -114,7 +114,8 @@ Custom property | Description | Default
          */
         valueObject: {
           type: Object,
-          notify: true
+          notify: true,
+		  observer: '_observeValueArray'
         },
 
         /**
@@ -159,22 +160,22 @@ Custom property | Description | Default
           type: String
         },
 
-        /* 
+        /*
          * `maxTags` the maximum allowed number of tags
          */
         maxTags: {
           type: Number
         },
 
-        /* 
+        /*
          * `minTags` the minimum allowed number of tags
          */
         minTags: {
           type: Number
         },
 
-        /* 
-         * `readonly` - reflects to `disabled` when set to true. 
+        /*
+         * `readonly` - reflects to `disabled` when set to true.
          */
         readonly: {
           type: Boolean,
@@ -320,20 +321,31 @@ Custom property | Description | Default
         // run every time item is set ore reset
         if (items) {
           this._isInitiatingItems = true;
-          this._observeValueArray();
+          this.set('tagItems', this._filterValueItems(this.valueArray));
 
           delete this._isInitiatingItems;
         }
       },
 
       _observeValueArray: function(splices) {
-        if (!this.valueArray) {
-          return;
-        }
-        this.set('tagItems', this.items.filter(function(item) {
-          return this.valueArray.indexOf((item[this.keyPath || item]) + '') > -1;
-        }, this));
+		// run on any change to the valueArray
+        this.set('tagItems', this._filterValueItems(this.valueArray));
       },
+
+	  _filterValueItems: function(valueArray) {
+		var filteredVals = [];
+		if (valueArray && this.items && this.items.length > 0) {
+		  filteredVals = this.items.filter(function(item) {
+			var itemKey = this.keyPath;
+			if (item[itemKey]) {
+			  return this.valueArray.indexOf(item[itemKey] + '') > -1;
+			}else {
+			  return this.valueArray.indexOf(item) > -1;
+			}
+		  }, this);
+		}
+		return filteredVals;
+	  },
 
       ready: function() {
         this.$.menuButton.ignoreSelect = true;


### PR DESCRIPTION
Attempting to use paper-tags-dropdown using a string array wasn't setting the tagItems property properly. Fixed this issue and added a demo section to demonstrate.